### PR TITLE
Feat/motrack motion

### DIFF
--- a/configs/algorithm/bytetrack.yaml
+++ b/configs/algorithm/bytetrack.yaml
@@ -7,6 +7,7 @@ params:
   new_tracklet_detection_threshold: 0.7
   remember_threshold: 30
   detection_threshold: 0.6
+  duplicate_iou_threshold: 1.00  # Disable
   high_matcher_algorithm: iou
   high_matcher_params:
     match_threshold: 0.25

--- a/configs/algorithm/reid_byte.yaml
+++ b/configs/algorithm/reid_byte.yaml
@@ -1,0 +1,40 @@
+name: byte
+params:
+  filter_name: bot-sort
+  filter_params:
+    override_std_weight_position: 0.05
+  initialization_threshold: 3
+  new_tracklet_detection_threshold: 0.7
+  remember_threshold: 60
+  detection_threshold: 0.6
+  high_matcher_algorithm: compose
+  high_matcher_params:
+    matchers:
+      - name: iou
+        params:
+         match_threshold: 0.15
+      - name: reid
+        params: {}
+    weights:
+      - 1.0
+      - 1.5
+  low_matcher_algorithm: compose
+  low_matcher_params:
+    matchers:
+      - name: iou
+        params:
+         match_threshold: 0.5
+    weights:
+      - 1.0
+  new_matcher_algorithm: iou
+  new_matcher_params:
+    match_threshold: 0.15
+
+  # ReID extension
+  reid_name: fastreid-onnx
+  reid_params:
+    model_path: /media/home/reid/SBS.onnx
+    height: 384
+    width: 128
+    cache_path: /tmp/reid_sbs50  # Cache inference for faster future runs (should be deleted if the detector changed)
+    batch_inference: false

--- a/configs/postprocess/dancetrack.yaml
+++ b/configs/postprocess/dancetrack.yaml
@@ -1,3 +1,4 @@
 init_threshold: 2
 linear_interpolation_threshold: 10
+linear_interpolation_min_tracklet_length: 30
 min_tracklet_length: 20

--- a/configs/postprocess/dancetrack.yaml
+++ b/configs/postprocess/dancetrack.yaml
@@ -1,3 +1,3 @@
-init_threshold: 0
-linear_interpolation_threshold: 3
+init_threshold: 2
+linear_interpolation_threshold: 10
 min_tracklet_length: 20

--- a/configs/reid_byte.yaml
+++ b/configs/reid_byte.yaml
@@ -1,0 +1,12 @@
+defaults:
+  - global_config
+  - dataset: dancetrack.yaml
+  - eval: val.yaml
+  - object_detection: yolox_dancetrack.yaml
+  - algorithm: reid_byte.yaml
+  - postprocess: dancetrack.yaml
+  - path: default.yaml
+  - _self_
+
+
+experiment: 'byte-reid'

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,20 @@
 # Changelog
 
-## 0.3.0 - Unreleased
+## 0.3.1 - 2024-01-11
+
+### Features
+- Implementation of HVC (improved Move) association method
+- Implementation of LongTermReID association method
+- Tracking postprocess now includes minimum tracklet length
+- Generalized Motrack-motion package support (usage of any motrack-motion filter)
+  - This currently includes the RNNFilter and TransFilter methods
+- Implementation of OC_SORT's observation centric momentum association methods
+- Implementation od DTIoU (decaying threshold) IoU based association method
+
+### Fixes
+- ByteTrack lost tracklets are properly extrapolated with a filter
+
+## 0.3.0 - 2023-12-31
 
 ### Features
 - Extension of motion filters with Motrack-motion library (End-to-end RNNFilter)

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -13,7 +13,7 @@ Default ReID model is the fast-reid SBS(S50).
 |-------------|--------------------------------------------------------|------|------|------|------------------|
 | FastTracker | no motion filter + IoU + Greedy                        | 46.0 | 88.7 | 44.4 | fast.yaml        |
 | Bot-SORT    | [arxiv: Bot-SORT](https://arxiv.org/abs/2206.14651)    | 51.3 | 90.4 | 52.2 | botsort.yaml     |
-| SORT        | [arxiv: SORT](https://arxiv.org/pdf/1602.00763.pdf)    | 51.4 | 89.6 | 51.2 | sort.yaml        |
+| SORT        | [arxiv: SORT](https://arxiv.org/pdf/1602.00763.pdf)    | 51.5 | 89.6 | 51.2 | sort.yaml        |
 | ByteTrack   | [arxiv: ByteTrack](https://arxiv.org/abs/2110.06864)   | 52.9 | 90.8 | 54.4 | bytetrack.yaml   |
 | SparseTrack | [arxiv: SparseTrack](https://arxiv.org/abs/2306.05238) | 52.4 | 90.0 | 52.7 | sparsetrack.yaml |
 | SORT-ReID   | SORT + ReID (FastReID SBS-S50)                         | 56.3 | 89.9 | 56.9 | sort_reid.yaml   |

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -14,7 +14,7 @@ Default ReID model is the fast-reid SBS(S50).
 | FastTracker | no motion filter + IoU + Greedy                        | 46.0 | 88.7 | 44.4 | fast.yaml        |
 | Bot-SORT    | [arxiv: Bot-SORT](https://arxiv.org/abs/2206.14651)    | 51.3 | 90.4 | 52.2 | botsort.yaml     |
 | SORT        | [arxiv: SORT](https://arxiv.org/pdf/1602.00763.pdf)    | 51.4 | 89.6 | 51.2 | sort.yaml        |
-| ByteTrack   | [arxiv: ByteTrack](https://arxiv.org/abs/2110.06864)   | 52.3 | 90.5 | 53.3 | bytetrack.yaml   |
+| ByteTrack   | [arxiv: ByteTrack](https://arxiv.org/abs/2110.06864)   | 52.9 | 90.8 | 54.4 | bytetrack.yaml   |
 | SparseTrack | [arxiv: SparseTrack](https://arxiv.org/abs/2306.05238) | 52.4 | 90.0 | 52.7 | sparsetrack.yaml |
 | SORT-ReID   | SORT + ReID (FastReID SBS-S50)                         | 56.3 | 89.9 | 56.9 | sort_reid.yaml   |
 

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -26,3 +26,4 @@ Custom architectures:
 | MoveSORT + CMC | SORT + Move association + CMC                           | 53.1 | 90.1 | 53.3 | movesort_gmc.yaml  |
 | MoveByte       | Byte + Move association                                 | 53.8 | 90.5 | 54.7 | movebyte.yaml      |
 | MoveByte + CKF | Byte + Move association + Confidence KF and association | 56.0 | 90.5 | 57.7 | movebyte_conf.yaml |
+| DeepMoveSORT   | Byte + ReID + HVC + Conf                                | 60.8 | 90.9 | 65.0 | coming_soon.yaml   |

--- a/motrack/config_parser/core.py
+++ b/motrack/config_parser/core.py
@@ -122,6 +122,7 @@ class TrackerPostprocessConfig:
 class TrackerEvalConfig:
     split: str
     postprocess: bool = field(default=False)
+    override: bool = field(default=False)
 
 
 @dataclass

--- a/motrack/config_parser/core.py
+++ b/motrack/config_parser/core.py
@@ -124,6 +124,7 @@ class TrackerEvalConfig:
     split: str
     postprocess: bool = field(default=False)
     override: bool = field(default=False)
+    load_image: bool = field(default=True)
 
 
 @dataclass

--- a/motrack/config_parser/core.py
+++ b/motrack/config_parser/core.py
@@ -115,6 +115,7 @@ class TrackerVisualizeConfig:
 class TrackerPostprocessConfig:
     init_threshold: int = 2  # Activate `init_threshold` starting bboxes
     linear_interpolation_threshold: int = 3  # Maximum distance to perform linear interpolation
+    linear_interpolation_min_tracklet_length: int = 30  # Minimum tracklet length to perform linear interpolation
     min_tracklet_length: int = 20  # Remove all tracklets that are shorter than this
 
 

--- a/motrack/tools/inference.py
+++ b/motrack/tools/inference.py
@@ -20,7 +20,8 @@ def run_tracker_inference(
     tracker_active_output: str,
     tracker_all_output: str,
     clip: bool = True,
-    scene_pattern: str = '(.*?)'
+    scene_pattern: str = '(.*?)',
+    load_image: bool = True
 ) -> None:
     """
     Performs inference on given dataset with a given tracker and detection manager.
@@ -33,6 +34,8 @@ def run_tracker_inference(
         tracker_all_output: Path where the all tracks are stored
         clip: Clip bounding boxes coordinates to range [0, 1]
         scene_pattern: Filter dataset scenes.
+        load_image: Load image for Object Detection or ReID model
+            - Can be set to False if everything is already cached
     """
     scene_names = dataset.scenes
     scene_names = [scene_name for scene_name in scene_names if re.match(scene_pattern, scene_name)]
@@ -59,7 +62,7 @@ def run_tracker_inference(
                     tracklets=tracklets,
                     detections=detection_bboxes,
                     frame_index=index + 1,  # Counts from 1 instead of 0
-                    frame=dataset.load_scene_image_by_frame_index(scene_name, index)
+                    frame=dataset.load_scene_image_by_frame_index(scene_name, index) if load_image else None
                 )
                 active_tracklets = [t for t in tracklets if t.state == TrackletState.ACTIVE]
 

--- a/motrack/tracker/matching/algorithms/horizontal_cues.py
+++ b/motrack/tracker/matching/algorithms/horizontal_cues.py
@@ -14,32 +14,38 @@ from motrack.tracker.tracklet import Tracklet
 @ASSOCIATION_CATALOG.register('hvc')
 class HorizontalViewCues(AssociationAlgorithm):
     """
-    Heuristic: When camera is positioned horizontally, bottom y position (bottom)
-    and height become important cues.
+    Heuristic: When camera is positioned horizontally,
+        bottom y position (bottom),
+        height,
+        and bounding box center
+        2323become important cues.
     """
     def __init__(
         self,
         bottom_position_factor: float = 1.0,
         height_factor: float = 1.0,
+        center_position_factor: float = 0.0,
         fast_linear_assignment: bool = False
     ):
         """
         Args:
             bottom_position_factor: Bottom position factor
             height_factor: Height factor
+            center_position_factor: Center position factor
             fast_linear_assignment: Use greedy algorithm for linear assignment
                 - This might be more efficient in case of large cost matrix
         """
         super().__init__(fast_linear_assignment=fast_linear_assignment)
         self._bottom_position_factor = bottom_position_factor
         self._height_factor = height_factor
+        self._center_position_factor = center_position_factor
 
     def form_cost_matrix(
-            self,
-            tracklet_estimations: List[PredBBox],
-            detections: List[PredBBox],
-            object_features: Optional[np.ndarray] = None,
-            tracklets: Optional[List[Tracklet]] = None
+        self,
+        tracklet_estimations: List[PredBBox],
+        detections: List[PredBBox],
+        object_features: Optional[np.ndarray] = None,
+        tracklets: Optional[List[Tracklet]] = None
     ) -> np.ndarray:
         _, _ = object_features, tracklets  # Unused
 
@@ -53,7 +59,11 @@ class HorizontalViewCues(AssociationAlgorithm):
 
                 bottom_diff = abs(tracklet_bbox.bottom_right.y - det_bbox.bottom_right.y)
                 height_diff = abs(tracklet_bbox.height - det_bbox.height)
+                center_diff = abs(tracklet_bbox.center.x - det_bbox.center.x)
 
-                cost_matrix[t_i][d_i] = self._bottom_position_factor * bottom_diff + self._height_factor * height_diff
+                cost_matrix[t_i][d_i] = \
+                    self._bottom_position_factor * bottom_diff \
+                    + self._height_factor * height_diff \
+                    + self._center_position_factor * center_diff
 
         return cost_matrix

--- a/motrack/tracker/matching/algorithms/horizontal_cues.py
+++ b/motrack/tracker/matching/algorithms/horizontal_cues.py
@@ -1,0 +1,59 @@
+"""
+Height and bottom position distance
+"""
+from typing import Optional, List
+
+import numpy as np
+
+from motrack.library.cv.bbox import PredBBox
+from motrack.tracker.matching.algorithms.base import AssociationAlgorithm
+from motrack.tracker.matching.catalog import ASSOCIATION_CATALOG
+from motrack.tracker.tracklet import Tracklet
+
+
+@ASSOCIATION_CATALOG.register('hvc')
+class HorizontalViewCues(AssociationAlgorithm):
+    """
+    Heuristic: When camera is positioned horizontally, bottom y position (bottom)
+    and height become important cues.
+    """
+    def __init__(
+        self,
+        bottom_position_factor: float = 1.0,
+        height_factor: float = 1.0,
+        fast_linear_assignment: bool = False
+    ):
+        """
+        Args:
+            bottom_position_factor: Bottom position factor
+            height_factor: Height factor
+            fast_linear_assignment: Use greedy algorithm for linear assignment
+                - This might be more efficient in case of large cost matrix
+        """
+        super().__init__(fast_linear_assignment=fast_linear_assignment)
+        self._bottom_position_factor = bottom_position_factor
+        self._height_factor = height_factor
+
+    def form_cost_matrix(
+            self,
+            tracklet_estimations: List[PredBBox],
+            detections: List[PredBBox],
+            object_features: Optional[np.ndarray] = None,
+            tracklets: Optional[List[Tracklet]] = None
+    ) -> np.ndarray:
+        _, _ = object_features, tracklets  # Unused
+
+        n_tracklets, n_detections = len(tracklet_estimations), len(detections)
+        cost_matrix = np.zeros(shape=(n_tracklets, n_detections), dtype=np.float32)
+        for t_i in range(n_tracklets):
+            tracklet_bbox = tracklet_estimations[t_i]
+
+            for d_i in range(n_detections):
+                det_bbox = detections[d_i]
+
+                bottom_diff = abs(tracklet_bbox.bottom_right.y - det_bbox.bottom_right.y)
+                height_diff = abs(tracklet_bbox.height - det_bbox.height)
+
+                cost_matrix[t_i][d_i] = self._bottom_position_factor * bottom_diff + self._height_factor * height_diff
+
+        return cost_matrix

--- a/motrack/tracker/matching/algorithms/iou.py
+++ b/motrack/tracker/matching/algorithms/iou.py
@@ -34,7 +34,6 @@ class IoUBasedAssociation(AssociationAlgorithm):
         super().__init__(fast_linear_assignment=fast_linear_assignment)
 
         self._label_gating = {tuple(e) for e in label_gating} if label_gating is not None else None
-        self._fast_linear_assignment = fast_linear_assignment
 
     def _can_match_labels(self, tracklet_label: LabelType, det_label: LabelType) -> bool:
         """

--- a/motrack/tracker/matching/algorithms/momentum.py
+++ b/motrack/tracker/matching/algorithms/momentum.py
@@ -1,0 +1,273 @@
+"""
+Momentum based association.
+"""
+from typing import Optional, List, Tuple
+
+import numpy as np
+
+from motrack.library.cv.bbox import PredBBox, Point
+from motrack.tracker.matching.algorithms.base import AssociationAlgorithm
+from motrack.tracker.matching.algorithms.utils import filter_observations
+from motrack.tracker.matching.catalog import ASSOCIATION_CATALOG
+from motrack.tracker.tracklet import Tracklet
+
+
+class MomentumAssociation(AssociationAlgorithm):
+    """
+    Standard negative IoU association with gating.
+    """
+    def __init__(
+        self,
+        momentum: int = 1,
+        fast_linear_assignment: bool = False
+    ):
+        """
+        Args:
+            momentum: Number of latest boxes (history) to consider for momentum association
+            fast_linear_assignment: Use greedy algorithm for linear assignment
+                - This might be more efficient in case of large cost matrix
+        """
+        super().__init__(fast_linear_assignment=fast_linear_assignment)
+
+        self._momentum = momentum
+
+    def form_cost_matrix(
+        self,
+        tracklet_estimations: List[PredBBox],
+        detections: List[PredBBox],
+        object_features: Optional[np.ndarray] = None,
+        tracklets: Optional[List[Tracklet]] = None
+    ) -> np.ndarray:
+        _ = object_features  # Unused
+
+        n_tracklets, n_detections = len(tracklet_estimations), len(detections)
+        cost_matrix = np.zeros(shape=(n_tracklets, n_detections), dtype=np.float32)
+        for t_i in range(n_tracklets):
+            tracklet = tracklets[t_i]
+            tracklet_bbox = tracklet_estimations[t_i]
+
+            for d_i in range(n_detections):
+                det_bbox = detections[d_i]
+
+                cost_matrix[t_i][d_i] = self._calc_momentum(tracklet, tracklet_bbox, det_bbox, self._momentum)
+
+        return cost_matrix
+
+    @staticmethod
+    def _calc_direction(point: Point, reference_point: Point) -> Tuple[float, float]:
+        """
+        Calculates unit direction given the point and the reference point.
+
+        Direction: reference_point -> point
+
+        Args:
+            point: Point
+            reference_point: Reference point
+
+        Returns:
+            Unit vector direction
+        """
+        direction_yx = point.y - reference_point.y, point.x - reference_point.x
+        norm = np.sqrt(direction_yx[0] ** 2 + direction_yx[1] ** 2) + 1e-6
+        direction_yx = (direction_yx[0] / norm, direction_yx[1] / norm)
+        return direction_yx
+
+    @staticmethod
+    def momentum_score(
+        tracklet_point: Point,
+        tracklet_reference_point: Point,
+        det_point: Point,
+        det_reference_point: Point,
+        conf: float
+    ) -> float:
+        """
+        Calculates momentum score based on the tracklet direction and the candidate detection direction.
+
+        Args:
+            tracklet_point: Tracklet last point
+            tracklet_reference_point: Tracklet previous point
+            det_point: Detection point
+            det_reference_point: Detection previous point
+            conf: Detection confidence
+
+        Returns:
+            Momentum (angle) score
+        """
+        theta_inertia_y, theta_inertia_x = MomentumAssociation._calc_direction(tracklet_point, tracklet_reference_point)
+        theta_intention_y, theta_intention_x = MomentumAssociation._calc_direction(det_point, det_reference_point)
+
+        # scalar product: <x, y>
+        # cos(theta) = <x, y> / (|x| * |y|)
+        # |x| = |y| = 1
+        # => theta = arcos(<x, y>)
+        diff_angle_cos = theta_inertia_y * theta_intention_y + theta_inertia_x * theta_intention_x
+        diff_angle_cos = np.clip(diff_angle_cos, a_min=-1, a_max=1)
+        diff_angle = np.arccos(diff_angle_cos)
+        diff_angle = (np.pi / 2.0 - np.abs(diff_angle)) / np.pi  # 1 in case of perfect match, 0 in case of bad match
+        return - conf * diff_angle
+
+    def _calc_momentum(self, tracklet: Tracklet, tracklet_bbox: PredBBox, det_bbox: PredBBox, momentum: int) -> float:
+        """
+        Calculates matching score (cost) between tracklet and a detection bounding box.
+
+        Args:
+            tracklet: Tracklet info
+            tracklet_bbox: Tracklet bounding box
+            det_bbox: Detection bounding box
+            momentum: Momentum
+
+        Returns:
+            Momentum score
+        """
+        raise NotImplementedError('Score calculation is not implemented!')
+
+@ASSOCIATION_CATALOG.register('ocm')
+class OCM(MomentumAssociation):
+    """
+    Observation Centric Momentum. Reference: https://arxiv.org/pdf/2203.14360.pdf
+    """
+    def __init__(
+        self,
+        delta_t: int = 3,
+        fast_linear_assignment: bool = False,
+    ):
+        """
+        Args:
+            delta_t: Time step between tracker bounding boxes to estimate the speed vector
+            fast_linear_assignment: Use greedy algorithm for linear assignment
+                - This might be more efficient in case of large cost matrix
+        """
+        super().__init__(fast_linear_assignment=fast_linear_assignment, momentum=1)
+        self._delta_t = delta_t
+
+    def _calc_momentum(self, tracklet: Tracklet, tracklet_bbox: PredBBox, det_bbox: PredBBox, momentum: int) -> float:
+        observation_history = filter_observations(tracklet.history)
+        current_frame_index = tracklet.frame_index + tracklet.lost_time + 1
+        latest_observation_history = [(index, bbox) for index, bbox in observation_history if index >= current_frame_index - self._delta_t - 1]
+
+        if len(latest_observation_history) < 2:
+            if len(observation_history) < 2:
+                return 0.0
+
+            _, last_bbox = observation_history[-1]
+            _, prev_bbox = observation_history[-2]
+            _, after_prev_bbox = observation_history[-1]
+        else:
+            _, last_bbox = latest_observation_history[-1]
+            _, prev_bbox = latest_observation_history[0]
+            _, after_prev_bbox = latest_observation_history[1]
+
+        return self.momentum_score(last_bbox.center, prev_bbox.center, det_bbox.center, after_prev_bbox.center, det_bbox.conf)
+
+
+@ASSOCIATION_CATALOG.register('robust-ocm')
+class RobustOCM(MomentumAssociation):
+    """
+    Robust OCM. Reference: https://arxiv.org/pdf/2308.00783.pdf
+    """
+    def __init__(
+        self,
+        momentum: int = 3,
+        fast_linear_assignment: bool = False,
+    ):
+        """
+        Args:
+            momentum: Number of latest boxes (history) to consider for momentum association
+            fast_linear_assignment: Use greedy algorithm for linear assignment
+                - This might be more efficient in case of large cost matrix
+        """
+        super().__init__(fast_linear_assignment=fast_linear_assignment, momentum=momentum)
+
+    @staticmethod
+    def _get_corner_points(bbox: PredBBox) -> List[Point]:
+        """
+        Gets all bounding box corner points.
+
+        Args:
+            bbox: Bounding box
+
+        Returns:
+            Bounding box 4 corner points
+        """
+        return [
+            Point(bbox.upper_left.x, bbox.upper_left.y),  # Upper Left
+            Point(bbox.bottom_right.x, bbox.upper_left.y),  # Upper right
+            Point(bbox.bottom_right.x, bbox.bottom_right.y),  # Bottom right
+            Point(bbox.upper_left.x, bbox.bottom_right.y)  # Bottom Left
+        ]
+
+    def _calc_momentum(self, tracklet: Tracklet, tracklet_bbox: PredBBox, det_bbox: PredBBox, momentum: int) -> float:
+        observation_history = filter_observations(tracklet.history)
+        current_frame_index = tracklet.frame_index + tracklet.lost_time + 1
+        latest_observation_history = [(index, bbox) for index, bbox in observation_history if index >= current_frame_index - self._momentum - 1]
+
+        if len(latest_observation_history) < 2:
+            if len(observation_history) < 2:
+                return 0.0
+
+            _, curr_bbox = observation_history[-1]
+            _, prev_bbox = observation_history[-2]
+            _, after_prev_bbox = observation_history[-1]
+
+            momentum_score: float = 0.0
+            for curr_point, prev_point, det_point, after_prev_point in zip(self._get_corner_points(curr_bbox), self._get_corner_points(prev_bbox),
+                                                         self._get_corner_points(det_bbox), self._get_corner_points(after_prev_bbox)):
+                momentum_score += self.momentum_score(curr_point, prev_point, det_point, after_prev_point, det_bbox.conf)
+
+            return momentum_score / 4
+
+        momentum_score: float = 0.0
+        for i in range(1, self._momentum + 1):
+            if i >= len(latest_observation_history):
+                continue
+
+            _, curr_bbox = latest_observation_history[-1]
+            _, prev_bbox = latest_observation_history[-i - 1]
+            _, after_prev_bbox = latest_observation_history[-i]
+
+            for curr_point, prev_point, det_point, after_prev_point in zip(self._get_corner_points(curr_bbox), self._get_corner_points(prev_bbox),
+                                                         self._get_corner_points(det_bbox), self._get_corner_points(after_prev_bbox)):
+                momentum_score += self.momentum_score(curr_point, prev_point, det_point, after_prev_point, det_bbox.conf)
+
+        return momentum_score / 4
+
+
+@ASSOCIATION_CATALOG.register('ecm')
+class ECM(OCM):
+    """
+    Estimation Centric Momentum. Like OCM but uses estimation instead of the last observation.
+    """
+    def _calc_momentum(self, tracklet: Tracklet, tracklet_bbox: PredBBox, det_bbox: PredBBox, momentum: int) -> float:
+        if len(tracklet.history) < self._delta_t:
+            prev_bbox = tracklet.bbox
+        else:
+            _, prev_bbox = tracklet.history[-self._delta_t]
+        return self.momentum_score(tracklet_bbox.center, prev_bbox.center, det_bbox.center, prev_bbox.center, det_bbox.conf)
+
+
+@ASSOCIATION_CATALOG.register('robust-ecm')
+class RobustECM(RobustOCM):
+    """
+    Like Robust OCM but uses estimation instead of the last observation.
+    """
+    def _calc_momentum(self, tracklet: Tracklet, tracklet_bbox: PredBBox, det_bbox: PredBBox, momentum: int) -> float:
+        if len(tracklet.history) < momentum:
+            prev_bbox = tracklet.bbox
+
+            momentum_score: float = 0.0
+            for tracklet_point, prev_point, det_point in zip(self._get_corner_points(tracklet_bbox), self._get_corner_points(prev_bbox),
+                                                             self._get_corner_points(det_bbox)):
+
+                momentum_score += self.momentum_score(tracklet_point, prev_point, det_point, prev_point, det_bbox.conf)
+
+            return momentum_score / 4
+
+        momentum_score: float = 0.0
+        for i in range(1, self._momentum + 1):
+            _, prev_bbox = tracklet.history[-i]
+
+            for tracklet_point, prev_point, det_point in zip(self._get_corner_points(tracklet_bbox), self._get_corner_points(prev_bbox),
+                                             self._get_corner_points(det_bbox)):
+                momentum_score += self.momentum_score(tracklet_point, prev_point, det_point, prev_point, det_bbox.conf)
+
+        return momentum_score / 4

--- a/motrack/tracker/matching/algorithms/utils.py
+++ b/motrack/tracker/matching/algorithms/utils.py
@@ -1,0 +1,29 @@
+"""
+Utility functions for association algorithm.
+"""
+from motrack.tracker.tracklet import TrackletHistoryType
+
+
+def filter_observations(history: TrackletHistoryType) -> TrackletHistoryType:
+    """
+    Remove all tracklet estimations. Estimations take place with
+    last observation index if the observation is missing (missed detection).
+
+    Disclaimer: This is coupled with MotionReId logic.
+
+    Args:
+        history:
+
+    Returns:
+        Tracklet observation history
+    """
+    last_frame_index: int = -1
+
+    observation_history: TrackletHistoryType = []
+    for index, bbox in history:
+        if last_frame_index == index:
+            continue
+        last_frame_index = index
+        observation_history.append((index, bbox))
+
+    return observation_history

--- a/motrack/tracker/matching/factory.py
+++ b/motrack/tracker/matching/factory.py
@@ -15,6 +15,8 @@ from motrack.tracker.matching.algorithms.conf import HybridConfidenceAssociation
 # noinspection PyUnresolvedReferences
 from motrack.tracker.matching.algorithms.dcm import DCMIoU, MoveDCM
 # noinspection PyUnresolvedReferences
+from motrack.tracker.matching.algorithms.horizontal_cues import HorizontalViewCues
+# noinspection PyUnresolvedReferences
 from motrack.tracker.matching.algorithms.iou import IoUAssociation, IoUAssociationAdaptiveGating, HMIoUAssociation
 # noinspection PyUnresolvedReferences
 from motrack.tracker.matching.algorithms.move import Move

--- a/motrack/tracker/matching/factory.py
+++ b/motrack/tracker/matching/factory.py
@@ -17,7 +17,7 @@ from motrack.tracker.matching.algorithms.dcm import DCMIoU, MoveDCM
 # noinspection PyUnresolvedReferences
 from motrack.tracker.matching.algorithms.horizontal_cues import HorizontalViewCues
 # noinspection PyUnresolvedReferences
-from motrack.tracker.matching.algorithms.iou import IoUAssociation, IoUAssociationAdaptiveGating, HMIoUAssociation
+from motrack.tracker.matching.algorithms.iou import IoUAssociation, IoUAssociationAdaptiveGating, HMIoUAssociation, DecayIoU
 # noinspection PyUnresolvedReferences
 from motrack.tracker.matching.algorithms.momentum import OCM, RobustOCM, ECM, RobustECM
 # noinspection PyUnresolvedReferences

--- a/motrack/tracker/matching/factory.py
+++ b/motrack/tracker/matching/factory.py
@@ -19,6 +19,8 @@ from motrack.tracker.matching.algorithms.horizontal_cues import HorizontalViewCu
 # noinspection PyUnresolvedReferences
 from motrack.tracker.matching.algorithms.iou import IoUAssociation, IoUAssociationAdaptiveGating, HMIoUAssociation
 # noinspection PyUnresolvedReferences
+from motrack.tracker.matching.algorithms.momentum import OCM, RobustOCM, ECM, RobustECM
+# noinspection PyUnresolvedReferences
 from motrack.tracker.matching.algorithms.move import Move
 # noinspection PyUnresolvedReferences
 from motrack.tracker.matching.algorithms.reid import ReIDIoUAssociation

--- a/motrack/tracker/trackers/algorithms/byte.py
+++ b/motrack/tracker/trackers/algorithms/byte.py
@@ -160,7 +160,7 @@ class ByteTracker(MotionReIDBasedTracker):
             unpack_n([(i, t, t_bbox) for i, (t, t_bbox) in enumerate(zip(tracklets, prior_tracklet_bboxes)) if t.state == TrackletState.NEW], n=3)
         new_matches, new_unmatched_tracklets_indices, new_unmatched_detections_indices = \
             self._new_match(tracklets_new_bboxes, remaining_high_detections,
-                            object_features=None, tracklets=tracklets_new)
+                            object_features=objects_features[remaining_high_detection_indices], tracklets=tracklets_new)
         new_matches = [(tracklets_new_indices[t_i], high_unmatched_detections_indices[d_i]) for t_i, d_i in new_matches]
         new_unmatched_tracklets_indices = [tracklets_new_indices[t_i] for t_i in new_unmatched_tracklets_indices]
         new_unmatched_detections_indices = [remaining_high_detection_indices[d_i] for d_i in new_unmatched_detections_indices]

--- a/motrack/tracker/trackers/algorithms/byte.py
+++ b/motrack/tracker/trackers/algorithms/byte.py
@@ -53,7 +53,8 @@ class ByteTracker(MotionReIDBasedTracker):
         new_tracklet_detection_threshold: Optional[float] = None,
         duplicate_iou_threshold: float = 0.85,
         use_observation_if_lost: bool = False,
-        appearance_ema_momentum: float = 0.95
+        appearance_ema_momentum: float = 0.95,
+        appearance_buffer: int = 0
     ):
         if filter_params is None:
             filter_params = {}
@@ -74,6 +75,7 @@ class ByteTracker(MotionReIDBasedTracker):
             use_observation_if_lost=use_observation_if_lost,
 
             appearance_ema_momentum=appearance_ema_momentum,
+            appearance_buffer=appearance_buffer,
             reid_detection_threshold=detection_threshold
         )
 

--- a/motrack/tracker/trackers/algorithms/sort.py
+++ b/motrack/tracker/trackers/algorithms/sort.py
@@ -81,11 +81,6 @@ class SortTracker(MotionReIDBasedTracker):
         matcher_params = {} if matcher_params is None else matcher_params
         self._matcher = association_factory(name=matcher_algorithm, params=matcher_params)
 
-        # Parameters
-        self._remember_threshold = remember_threshold
-        self._initialization_threshold = initialization_threshold
-        self._use_observation_if_lost = use_observation_if_lost
-
     def _track(
         self,
         tracklets: List[Tracklet],

--- a/motrack/tracker/trackers/algorithms/sort.py
+++ b/motrack/tracker/trackers/algorithms/sort.py
@@ -34,7 +34,8 @@ class SortTracker(MotionReIDBasedTracker):
         initialization_threshold: int = 3,
         new_tracklet_detection_threshold: Optional[float] = None,
         use_observation_if_lost: bool = False,
-        appearance_ema_momentum: float = 0.95
+        appearance_ema_momentum: float = 0.95,
+        appearance_buffer: int = 0
     ):
         """
         Args:
@@ -54,6 +55,7 @@ class SortTracker(MotionReIDBasedTracker):
             initialization_threshold: Number of frames until tracklet becomes active
             new_tracklet_detection_threshold: Threshold to accept new tracklet
             use_observation_if_lost: When re-finding tracklet, use observation instead of estimation
+            appearance_buffer: Appearance buffer length (set to a non-zero non-negative integer to activate)
         """
         if filter_params is None:
             filter_params = {}
@@ -72,7 +74,8 @@ class SortTracker(MotionReIDBasedTracker):
             initialization_threshold=initialization_threshold,
             use_observation_if_lost=use_observation_if_lost,
 
-            appearance_ema_momentum=appearance_ema_momentum
+            appearance_ema_momentum=appearance_ema_momentum,
+            appearance_buffer=appearance_buffer
         )
 
         matcher_params = {} if matcher_params is None else matcher_params

--- a/motrack/tracker/tracklet.py
+++ b/motrack/tracker/tracklet.py
@@ -18,6 +18,7 @@ class TrackletCommonData(enum.Enum):
     Tracklet common data type used.
     """
     APPEARANCE = 'appearance'
+    APPEARANCE_BUFFER = 'appearance-buffer'
 
 
 class TrackletState(enum.Enum):

--- a/motrack/tracker/tracklet.py
+++ b/motrack/tracker/tracklet.py
@@ -7,7 +7,7 @@ from typing import Tuple, ClassVar, Optional, List, Any, Union
 
 from motrack.library.cv.bbox import PredBBox
 
-_TRACKLET_DEFAULT_MAX_HISTORY = 8
+_TRACKLET_DEFAULT_MAX_HISTORY = 32
 
 TrackletHistoryType = List[Tuple[int, PredBBox]]
 
@@ -240,11 +240,11 @@ class Tracklet:
         """
         bbox.id = self._id  # Update bbox id
 
-        # Remove `obsolete` history
-        while len(self._history) > 1 and frame_index - self.first[0] > self._max_history:
-            self._history.pop(0)
-
         self._history.append((frame_index, bbox))
+
+        # Remove `obsolete` history
+        while len(self._history) > self._max_history:
+            self._history.pop(0)
 
         if state is not None:
             self._state = state

--- a/motrack/version.py
+++ b/motrack/version.py
@@ -1,4 +1,4 @@
 """
 Package version.
 """
-__version__ = '0.3.0'
+__version__ = '0.3.1'

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ scipy>=1.10.0
 tqdm
 ultralytics
 torch
-motrack-motion
+motrack-motion>=0.2.2

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -68,7 +68,8 @@ def run_inference(cfg: GlobalConfig) -> None:
         tracker_active_output=tracker_active_output,
         tracker_all_output=tracker_all_output,
         clip=cfg.dataset.type != 'MOT17',
-        scene_pattern=cfg.dataset_filter.scene_pattern
+        scene_pattern=cfg.dataset_filter.scene_pattern,
+        load_image=cfg.eval.load_image
     )
 
     # Save tracker config

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -24,7 +24,11 @@ logger = logging.getLogger('TrackerInference')
 @pipeline.task('inference')
 def run_inference(cfg: GlobalConfig) -> None:
     if os.path.exists(cfg.experiment_path):
-        user_input = input(f'Experiment on path "{cfg.experiment_path}" already exists. Are you sure you want to override it? [yes/no] ').lower()
+        if cfg.eval.override:
+            user_input = 'yes'  # `input` from config
+        else:
+            user_input = input(f'Experiment on path "{cfg.experiment_path}" already exists. '
+                               f'Are you sure you want to override it? [yes/no] ').lower()
         if user_input in ['yes', 'y']:
             shutil.rmtree(cfg.experiment_path)
         else:


### PR DESCRIPTION
# Release 0.3.1

## Features
- Implementation of HVC (improved Move) association method
- Implementation of LongTermReID association method
- Tracking postprocess now includes minimum tracklet length
- Generalized Motrack-motion package support (usage of any motrack-motion filter)
  - This currently includes the RNNFilter and TransFilter methods
- Implementation of OC_SORT's observation centric momentum association methods
- Implementation od DTIoU (decaying threshold) IoU based association method

## Fixes
- ByteTrack lost tracklets are properly extrapolated with a filter